### PR TITLE
セキュリティアラート対応のため、serialize-javascriptのバージョンをしれっと上げる

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1927,7 +1927,7 @@ compression-webpack-plugin@^3.0.0:
     find-cache-dir "^3.0.0"
     neo-async "^2.5.0"
     schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
+    serialize-javascript "^2.1.1"
     webpack-sources "^1.0.1"
 
 compression@^1.7.4:
@@ -6673,11 +6673,6 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-javascript@^1.4.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
 serialize-javascript@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
これで動いてくれたので一旦ヨシ

webpackerの依存先のcompression-webpack-pluginの依存先のserialize-javascriptのバージョンがロックされているが、

compression-webpack-plugin/issues/138

これと同リポジトリのdependantbotのPRがビルドコケてるまま放置されている見る限り、リポジトリを運用するやる気があんまりなさそう

yarn.lockのバージョンをしれっと変更してyarn installを実行、結果ローカルとpirika環境の両方で動いたので問題なしと判断して入れちゃうことにします